### PR TITLE
Add fbx and bvh mobile share

### DIFF
--- a/ReactNative/components/preview/viewer.tsx
+++ b/ReactNative/components/preview/viewer.tsx
@@ -1,12 +1,13 @@
 import { Canvas } from '@react-three/fiber';
 import * as THREE from 'three';
 import { Model } from './model';
-import { IEstimation } from '../../helpers/api.types';
+import { AttachmentType, IEstimation } from '../../helpers/api.types';
 import { useEffect, useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { getBvh } from '../../helpers/api';
 import { useAccessToken } from '../../hooks/use-access-token';
 import { useNav } from '../../hooks/use-nav';
+import { ShareFileButton } from '../ui/buttons/shareFileButton';
 
 
 export type Props = {
@@ -42,7 +43,7 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
 
 
     return (
-        <View style={{ flex: 1, justifyContent: 'space-evenly', alignItems: 'center', display: estimation === null || bvhData === null ? 'none' : 'flex'  }}>
+        <View style={{ flex: 1, justifyContent: 'space-evenly', alignItems: 'center', display: estimation === null || bvhData === null ? 'none' : 'flex' }}>
             <Canvas
                 camera={camera}
                 gl={{ antialias: true }}
@@ -70,6 +71,8 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
                     <Text style={styles.greeting}>{estimation.displayName}</Text>
                     <Text>{estimation.tags.join(",")}</Text>
                     <Button disabled={bvhData === null} title="close" onPress={() => (setEstimation(null), setBvhData(null))} />
+                    <ShareFileButton attachmentType={AttachmentType.Bvh} estimation={estimation} text='Share BVH'/>
+                    <ShareFileButton attachmentType={AttachmentType.Fbx} estimation={estimation} text='Share FBX'/>
                 </>
             )}
         </View>

--- a/ReactNative/components/ui/buttons/buttons.types.ts
+++ b/ReactNative/components/ui/buttons/buttons.types.ts
@@ -1,0 +1,19 @@
+import { ViewStyle } from "react-native";
+import { StyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
+import { AttachmentType, IEstimation } from "../../../helpers/api.types";
+
+export type iconButtonProps = {
+    onPress?: () => void,
+    iconColor?: string,
+    icon?: string,
+    text: string,
+    containerStyle?: StyleProp<ViewStyle> | undefined,
+    disabled?: boolean,
+    iconSize?: number
+};
+
+export type shareFileButtonProps = iconButtonProps & {
+    onShareFinished?: () => void,
+    estimation: IEstimation,
+    attachmentType: AttachmentType
+};

--- a/ReactNative/components/ui/buttons/iconTextButton.tsx
+++ b/ReactNative/components/ui/buttons/iconTextButton.tsx
@@ -1,23 +1,16 @@
 import * as React from 'react';
-import { View, Text, StyleProp, ViewStyle } from 'react-native';
+import { View, Text } from 'react-native';
 import { IconButton } from 'react-native-paper';
+import { iconButtonProps } from './buttons.types';
 
-export type Props = {
-    onPress: () => void,
-    iconColor: string,
-    icon: string,
-    text: string,
-    containerStyle?: StyleProp<ViewStyle> | undefined,
-    iconSize: number
-};
-
-export const IconTextButton: React.FC<Props> = ({ onPress, icon, iconColor, text, containerStyle, iconSize }) => {
+export const IconTextButton: React.FC<iconButtonProps> = ({ onPress, icon, iconColor, text, containerStyle, iconSize, disabled = false }) => {
     return (
         <View style={containerStyle ?? { alignItems: 'center' }}>
             <IconButton
-                icon={icon}
+                icon={icon ?? 'alien'} // oh no 👽
                 iconColor={iconColor}
-                size={iconSize}
+                size={iconSize ?? 20}
+                disabled={disabled}
                 onPress={onPress} />
             <Text style={{ color: iconColor }}>{text}</Text>
         </View>

--- a/ReactNative/components/ui/buttons/shareFileButton.tsx
+++ b/ReactNative/components/ui/buttons/shareFileButton.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { AttachmentType } from '../../../helpers/api.types';
+import * as Sharing from 'expo-sharing';
+import { downloadAndStoreAttachment } from '../../../helpers/api';
+import { useAccessToken } from '../../../hooks/use-access-token';
+import { useState } from 'react';
+import { IconTextButton } from './iconTextButton';
+import { shareFileButtonProps } from './buttons.types';
+
+enum LoadState {
+    Loading,
+    Loaded,
+    Failed,
+    NotStarted
+}
+
+export const ShareFileButton: React.FC<shareFileButtonProps> = ({ onShareFinished, icon, iconColor, text, containerStyle, iconSize, estimation, attachmentType }) => {
+
+    const { accessToken } = useAccessToken();
+    const [loadState, setLoadState] = useState<LoadState>(LoadState.NotStarted);
+
+    const shareFile = async (filePath: string) => {
+
+        if (!(await Sharing.isAvailableAsync())) {
+            console.warn("Can't share, not available")
+            return;
+        }
+
+        await Sharing.shareAsync(filePath);
+
+        if (onShareFinished) {
+            onShareFinished();
+        }
+
+    };
+
+    const handleDownloadAndShare = async (attachmentType: AttachmentType) => {
+        try {
+            setLoadState(LoadState.Loading)
+            const filePath = await downloadAndStoreAttachment(accessToken.accessToken, estimation.internalGuid, estimation.displayName, attachmentType);
+            if (filePath) {
+                await shareFile(filePath);
+            }
+            setLoadState(LoadState.Loaded)
+        } catch (error) {
+            setLoadState(LoadState.Failed)
+            console.error("Error sharing file:", error);
+        }
+    };
+
+    return (
+        <IconTextButton
+            icon={icon ?? 'share'}
+            iconColor={iconColor}
+            iconSize={iconSize}
+            disabled={loadState === LoadState.Loading}
+            onPress={() => handleDownloadAndShare(attachmentType)} text={text} />
+    );
+}

--- a/ReactNative/helpers/api.ts
+++ b/ReactNative/helpers/api.ts
@@ -1,34 +1,73 @@
 import axios from 'axios';
 import { IEstimation, AttachmentType } from './api.types';
+import * as FileSystem from 'expo-file-system';
 
-const apiCall = async (url: string , token: string) => {
-    try {
-      const response = await axios.get(url, {
+const apiCall = async (url: string, token: string) => {
+  try {
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-CSRF': '1'
+      },
+    }).catch(e => console.error("ex", JSON.stringify(e)));;
+
+    if (!response) {
+      var noDataError = new Error("Data is missing")
+      console.error(noDataError);
+      throw noDataError;
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error("Error making authenticated API call:", error);
+  }
+};
+
+const checkFileExists = async (filePath: string) => {
+  try {
+    const fileInfo = await FileSystem.getInfoAsync(filePath);
+    return fileInfo.exists;
+  } catch (error) {
+    console.error("Error checking file existence:", error);
+    return false;
+  }
+};
+
+const downloadAndStoreAttachment = async (token: string, estimationGuid: string, name: string, attachmentType: AttachmentType) => {
+  try {
+
+    const response = await axios.get(`https://poseify.ngrok.app/api/GetAttachment?estimationId=${estimationGuid}&attachmentType=${attachmentType}`,
+      {
+        responseType: 'arraybuffer',
         headers: {
           Authorization: `Bearer ${token}`,
           'X-CSRF': '1'
-        },
-      }).catch(e => console.error("ex", JSON.stringify(e)));;
-  
-      if(!response){
-        var noDataError = new Error("Data is missing")
-        console.error(noDataError);
-        throw noDataError;
-      }
+        }
+      })
+    const filePath = `${FileSystem.documentDirectory}${name.substring(0, 8)}_${estimationGuid.substring(0, 5)}.${attachmentType.toLocaleLowerCase()}`;
 
-      return response.data;
-    } catch (error) {
-      console.error("Error making authenticated API call:", error);
+    if (!(await checkFileExists(filePath))) {
+      // if the file isn't downloaded yet then we should download it
+      console.log("Downloading Attachment", estimationGuid)
+      await FileSystem.writeAsStringAsync(filePath, response.request._response, {
+        encoding: FileSystem.EncodingType.Base64
+      });
     }
-  };
+
+    return filePath;
+  } catch (error) {
+    console.error("Error downloading file:", error);
+    throw error;
+  }
+}
 
 const getUserEstimations = async (token: string): Promise<IEstimation[]> => apiCall("https://poseify.ngrok.app/api/GetUserEstimations", token);
-const getUser = async(token: string): Promise<any> => apiCall("https://poseify.ngrok.app/bff/user", token);
-const getBvh = async(estimation: IEstimation, token: string): Promise<string> => {
+const getUser = async (token: string): Promise<any> => apiCall("https://poseify.ngrok.app/bff/user", token);
+const getBvh = async (estimation: IEstimation, token: string): Promise<string> => {
   const url = `https://poseify.ngrok.app/api/GetAttachment?estimationId=${estimation.internalGuid}&attachmentType=${AttachmentType.Bvh}`
   const response = await apiCall(url, token);
   //console.log("response", response)
   return response;
 }
 
-export {getUserEstimations, getUser, getBvh}
+export { getUserEstimations, getUser, getBvh, downloadAndStoreAttachment }

--- a/ReactNative/package-lock.json
+++ b/ReactNative/package-lock.json
@@ -18,6 +18,7 @@
         "expo-build-properties": "~0.8.3",
         "expo-constants": "~14.4.2",
         "expo-file-system": "~15.4.4",
+        "expo-sharing": "~11.5.0",
         "expo-splash-screen": "~0.20.5",
         "expo-status-bar": "~1.6.0",
         "jotai": "^2.5.0",
@@ -8086,6 +8087,14 @@
       "dependencies": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-11.5.0.tgz",
+      "integrity": "sha512-uerM5YH1FKDZXfkP9ORebvlMVOPP/AfoYgYBez6a8G9fztNYHnRCA6mgK+3aQmpnb3ltmjnAZC39kH18bTNcVw==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {
@@ -20492,6 +20501,12 @@
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
       }
+    },
+    "expo-sharing": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-11.5.0.tgz",
+      "integrity": "sha512-uerM5YH1FKDZXfkP9ORebvlMVOPP/AfoYgYBez6a8G9fztNYHnRCA6mgK+3aQmpnb3ltmjnAZC39kH18bTNcVw==",
+      "requires": {}
     },
     "expo-splash-screen": {
       "version": "0.20.5",

--- a/ReactNative/package.json
+++ b/ReactNative/package.json
@@ -30,7 +30,8 @@
     "expo-constants": "~14.4.2",
     "expo-av": "~13.4.1",
     "expo-file-system": "~15.4.4",
-    "expo-splash-screen": "~0.20.5"
+    "expo-splash-screen": "~0.20.5",
+    "expo-sharing": "~11.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Add fbx and bvh mobile share, The file is downloaded, except if the file has already been downloaded, once the share button has been pressed. This means there's a bit of load time when you want to share a file that still needs to be downloaded. Currently, no spinner is displayed but this will change in the future. 

To make it reusable I've expanded the IconTextButton to be wrapped by ShareFileButton.