### PR TITLE
Fix countdown below 0

### DIFF
--- a/ReactNative/pages/recording.tsx
+++ b/ReactNative/pages/recording.tsx
@@ -36,7 +36,7 @@ const Recording: React.FC<Props> = ({
         }
 
         // When countdown reaches 0, stop the timer
-        if (countdown === 0) {
+        if (countdown <= 0) {
             if (isActive) {
                 camera.current?.stopRecording();
             }


### PR DESCRIPTION
Checking if the value is exactly 0, can lead to scenarios where this condition isn't true.
If it skips 0 due to issues with floating point numbers, it is possible it might never reach the exact number of 0 but something like -0.2.
