### PR TITLE
Fix alien when no tags found

### DIFF
--- a/ReactNative/components/preview/viewer.tsx
+++ b/ReactNative/components/preview/viewer.tsx
@@ -84,7 +84,7 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
                     <View style={{ flexGrow: 0.5, justifyContent: 'space-evenly', alignItems: 'center', width: '100%' }}>
                         <View style={{ flexGrow: 1, flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center', width: '100%', gap: 4 }}>
                             {   // workaround for tags bug
-                                (estimation?.tags[0] ?? '').split(",").map((tag, i) => <Chip key={i} icon={getIconName(tag)}>{tag}</Chip>)
+                                (estimation?.tags[0] ?? '').split(",").filter(tag => tag.length > 0).map((tag, i) => <Chip key={i} icon={getIconName(tag)}>{tag}</Chip>)
                             }
                         </View>
 

--- a/ReactNative/hooks/use-nav.ts
+++ b/ReactNative/hooks/use-nav.ts
@@ -1,5 +1,4 @@
 import { IEstimation } from './../helpers/api.types';
-import * as AuthSession from 'expo-auth-session';
 import { useAtom } from 'jotai';
 import { navAtom } from '../store/navstore';
 


### PR DESCRIPTION
An alien emoji would appear when no tags are defined.
We do not want to display that alien...for obvious reasons.
This happens because the alien is the default icon when no text is found.