### PR TITLE
Fix file extension from jpg to mp4

### DIFF
--- a/ReactNative/helpers/upload.ts
+++ b/ReactNative/helpers/upload.ts
@@ -14,8 +14,8 @@ export const uploadFile = async (token: string, fileUri: string, estimationName:
         // Append the file for uploading
         formData.append("FormFile", {
             uri: fileInfo.uri,
-            type: 'image/jpeg', // or the correct file type
-            name: 'photo.jpg', // or the correct file name
+            type: 'video/mp4',
+            name: 'upload.mp4', // filename is overwritten, file extension is the only thing that matters
         });
 
         formData.append("EstimationName", estimationName);


### PR DESCRIPTION
The video file was saved as a .jpg because the file ending was incorrect in the FormFile.
The file's name doesn't matter, since it gets replaced in the backend anyway.
The file extension though is crucial for the backend to process the file correctly.