### PR TITLE
Fix performance in viewer by blocking rerenders

### DIFF
--- a/ReactNative/components/ui/list/animationsList.tsx
+++ b/ReactNative/components/ui/list/animationsList.tsx
@@ -13,7 +13,7 @@ export const AnimationsList: React.FC = () => {
     console.log("|| AnimationList")
     const { accessToken } = useAccessToken();
     const { getEstimations, setEstimations } = useEstimations();
-    const { setEstimation } = useNav();
+    const { setEstimation, getEstimation } = useNav();
     const [initLoaded, setInitiLoaded] = useState<boolean>(false);
 
     const [infoMessage, setInfoMessage] = useState<string | null>(null);
@@ -23,10 +23,22 @@ export const AnimationsList: React.FC = () => {
         setEstimations(result);
     }
 
-    const refreshTimer = 10000;
-    useInterval(() => (updateList(), console.log(`Updated after ${refreshTimer}`)), 10000)
+    const refreshTimer = 30000;
+    useInterval(() => {
+
+        if(getEstimation() !== null){
+            // If youre focused on an estimation, we don't want to update the animation list.
+            // We want to avoid rerenders while in the animation viewer.
+            return;
+        }
+
+        updateList()
+        console.log(`Updated after ${refreshTimer}`)
+    }, refreshTimer)
 
     useEffect(() => {
+        console.log('Reloading due to access token or nav')
+
         updateList();
         if (!initLoaded) {
             setInitiLoaded(true);

--- a/ReactNative/helpers/api.ts
+++ b/ReactNative/helpers/api.ts
@@ -3,6 +3,7 @@ import { IEstimation, AttachmentType } from './api.types';
 import * as FileSystem from 'expo-file-system';
 
 const apiCall = async (url: string, token: string) => {
+  console.log("API: " + url);
   try {
     const response = await axios.get(url, {
       headers: {


### PR DESCRIPTION
Fixed performance by not doing a rerender when the 3d viewer is open.