### PR TITLE
Add delete for animations

### DIFF
--- a/ReactNative/components/preview/viewer.tsx
+++ b/ReactNative/components/preview/viewer.tsx
@@ -4,13 +4,18 @@ import { Model } from './model';
 import { AttachmentType, IEstimation } from '../../helpers/api.types';
 import { useEffect, useState } from 'react';
 import { View } from 'react-native';
-import { getBvh } from '../../helpers/api';
+import { deleteAnimation, getBvh } from '../../helpers/api';
 import { useAccessToken } from '../../hooks/use-access-token';
 import { useNav } from '../../hooks/use-nav';
 import { ShareFileButton } from '../ui/buttons/shareFileButton';
 import { Appbar, Chip } from 'react-native-paper';
 import { TextSpinner } from '../ui/loading/textSpinner';
 import { getIconName } from '../../helpers/tags';
+import { ConfirmApiDialog } from '../ui/confirm/confirmApiDialog';
+import React from 'react';
+
+
+const MemoizedConfirmDialog = React.memo(ConfirmApiDialog);
 
 
 export type Props = {
@@ -24,6 +29,7 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
     const { accessToken } = useAccessToken();
     const { setEstimation } = useNav();
     const [isLoaded, setIsLoaded] = useState<boolean>(false);
+    const [deleteVisible, setDeleteVisible] = useState<boolean>(false);
 
     const camera = new THREE.PerspectiveCamera(80)
     camera.position.set(1, 2, 4)
@@ -52,8 +58,20 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
                 <Appbar.Header>
                     <Appbar.BackAction onPress={() => (setEstimation(null), setBvhData(null), setIsLoaded(false))} />
                     <Appbar.Content title={estimation.displayName} />
+                    <Appbar.Action icon={'delete'} onPress={() => setDeleteVisible(true)} />
                 </Appbar.Header>
-                {!isLoaded && (<TextSpinner label='Loading Your Animation! 🎬' />)}</>
+                {!isLoaded && (<TextSpinner label='Loading Your Animation! 🎬' />)}
+                <MemoizedConfirmDialog
+                    apiCall={deleteAnimation}
+                    apiProps={[accessToken.accessToken, estimation.internalGuid]}
+                    visible={deleteVisible}
+                    hideDialog={() => setDeleteVisible(false)}
+                    startButtonText='Delete'
+                    text='Delete this animation?'
+                    apiDoneText='Animation is deleted!'
+                    apiLoadingText='Deleting your animation...'
+                />
+            </>
             )}
 
             <View style={{ flex: 1, justifyContent: 'space-evenly', alignItems: 'center', display: estimation === null || bvhData === null ? 'none' : 'flex' }}>
@@ -61,7 +79,6 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
                     camera={camera}
                     gl={{ antialias: true }}
                     onCreated={(state) => {
-                        console.log("created");
                         state.scene.background = new THREE.Color("#f0f0f0");
                         state.scene.add(new THREE.GridHelper(5, 10));
                         const _gl = state.gl.getContext();
@@ -75,14 +92,14 @@ export const Viewer: React.FC<Props> = ({ estimation }) => {
                         setIsLoaded(true);
                     }
                     }
-                    style={{ width: "100%", maxHeight: "50%", height: "50%", display: estimation === null || bvhData === null ? 'none' : 'flex' }}>
+                    style={{ width: "100%", maxHeight: "50%", height: "50%", display: estimation === null || bvhData === null ? 'none' : 'flex', zIndex: -1 }}>
                     <ambientLight />
                     <pointLight position={[10, 10, 10]} />
                     <Model bvhData={bvhData} />
                 </Canvas>
                 {estimation && isLoaded && (
                     <View style={{ flexGrow: 0.5, justifyContent: 'space-evenly', alignItems: 'center', width: '100%' }}>
-                        <View style={{ flexGrow: 1, flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center', width: '100%', gap: 4 }}>
+                        <View style={{ flexGrow: 1, flexDirection: 'row', justifyContent: 'space-evenly', alignItems: 'center', width: '100%', gap: 4, zIndex: -1 }}>
                             {   // workaround for tags bug
                                 (estimation?.tags[0] ?? '').split(",").filter(tag => tag.length > 0).map((tag, i) => <Chip key={i} icon={getIconName(tag)}>{tag}</Chip>)
                             }

--- a/ReactNative/components/ui/confirm/confirmApiDialog.tsx
+++ b/ReactNative/components/ui/confirm/confirmApiDialog.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Button, Dialog, Portal, Text } from 'react-native-paper';
+import { useNav } from '../../../hooks/use-nav';
+import { TextSpinner } from '../loading/textSpinner';
+
+type ApiState = 'beforeApi' | 'duringApi' | 'afterApi'
+
+export const ConfirmApiDialog:
+    React.FC<{ visible: boolean, hideDialog: () => any, apiCall: (...args: any) => any, apiProps: any[], text: string, startButtonText: string, apiLoadingText: string, apiDoneText: string }> =
+    ({ visible, hideDialog, apiCall, apiProps, text, startButtonText, apiLoadingText, apiDoneText }) => {
+        console.log("|| ConfirmApiDialog")
+        const [apiState, setApiState] = React.useState<ApiState>('beforeApi');
+        const { setCurrentPage } = useNav();
+
+        const action = async () => {
+            setApiState('duringApi');
+            await apiCall(...apiProps);
+            setApiState('afterApi')
+        }
+
+        return (
+            <Portal>
+                <Dialog style={{ position: 'absolute', width: '80%', justifyContent: 'space-evenly', gap: 10 }} visible={visible} onDismiss={hideDialog}>
+                    <Dialog.Title>Delete Animation</Dialog.Title>
+                    {apiState === 'beforeApi' && (
+                        <Dialog.Content style={{ justifyContent: 'space-evenly', gap: 15 }}>
+                            <Text variant="bodyMedium">{text}</Text>
+                        </Dialog.Content>
+                    )}
+                    {apiState === 'duringApi' && (
+                        <Dialog.Content style={{ justifyContent: 'space-evenly', gap: 15 }}>
+                            <TextSpinner label={apiLoadingText} />
+                        </Dialog.Content>
+                    )}
+                    {apiState === 'afterApi' && (
+                        <Dialog.Content style={{ justifyContent: 'space-evenly', gap: 15 }}>
+                            <Text variant="bodyMedium">{apiDoneText}</Text>
+                        </Dialog.Content>
+                    )}
+                    {apiState !== 'afterApi' ? (
+                        <Dialog.Actions>
+                            <Button onPress={hideDialog} disabled={apiState !== 'beforeApi'}>Cancel</Button>
+                            <Button onPress={() => action()} disabled={apiState !== 'beforeApi'}>{startButtonText}</Button>
+                        </Dialog.Actions>
+                    ) : (
+                        <Dialog.Actions>
+                            <Button onPress={() => (setCurrentPage(0), hideDialog())}>Go to Animations</Button>
+                        </Dialog.Actions>
+                    )}
+                </Dialog>
+            </Portal>
+        );
+    }

--- a/ReactNative/components/ui/list/animationsList.tsx
+++ b/ReactNative/components/ui/list/animationsList.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { useAccessToken } from "../../../hooks/use-access-token";
 import { useNav } from "../../../hooks/use-nav";
-import { getUserEstimations } from "../../../helpers/api";
+import { deleteAnimation, getUserEstimations } from "../../../helpers/api";
 import { EndlessList } from "./endlessList";
 import { StyleSheet, View } from "react-native";
 import useInterval from "../../../hooks/use-interval";
 import { useEstimations } from "../../../hooks/use-estimations";
 import { Snackbar } from "react-native-paper";
 import { EstimationState, IEstimation } from "../../../helpers/api.types";
+import { useArrayEquals } from "../../../hooks/use-array-equals";
+import { ConfirmApiDialog } from "../confirm/confirmApiDialog";
 
 export const AnimationsList: React.FC = () => {
     console.log("|| AnimationList")
@@ -15,18 +17,24 @@ export const AnimationsList: React.FC = () => {
     const { getEstimations, setEstimations } = useEstimations();
     const { setEstimation, getEstimation } = useNav();
     const [initLoaded, setInitiLoaded] = useState<boolean>(false);
+    const { arraysAreEqual } = useArrayEquals();
+    const [deleteVisible, setDeleteVisible] = useState<boolean>(false);
 
-    const [infoMessage, setInfoMessage] = useState<string | null>(null);
+    const [info, setInfo] = useState<{ estimationId: string, message: string, estimationState: EstimationState } | null>(null);
+    const [snackbarVisible, setSnackbarVisible] = useState<boolean>(false);
 
     const updateList = async () => {
         const result = await getUserEstimations(accessToken.accessToken);
-        setEstimations(result);
+
+        if (!arraysAreEqual(result, getEstimations() ?? [])) {
+            setEstimations(result);
+        }
     }
 
     const refreshTimer = 30000;
     useInterval(() => {
 
-        if(getEstimation() !== null){
+        if (getEstimation() !== null) {
             // If youre focused on an estimation, we don't want to update the animation list.
             // We want to avoid rerenders while in the animation viewer.
             return;
@@ -53,25 +61,41 @@ export const AnimationsList: React.FC = () => {
         } else if (estimation.state === EstimationState.Failed) {
             return 'Sadly failed... 😔\n' + estimation.stateText;
         }
-        return null;
+        return '...';
     }
 
     return (
 
         <View style={styles.container}>
             <>
-                <EndlessList displaySpinner={!initLoaded} estimations={getEstimations() ?? []} loadData={() => updateList()} open={(e) => setEstimation(e)} info={(e) => setInfoMessage(buildInfoMessage(e))} />
+                <EndlessList displaySpinner={!initLoaded} estimations={getEstimations() ?? []} loadData={() => updateList()} open={(e) => setEstimation(e)} info={(e) => (setInfo({ estimationId: e.internalGuid, message: buildInfoMessage(e), estimationState: e.state }), setSnackbarVisible(true))} />
                 <Snackbar
-                    visible={infoMessage !== null}
-                    onDismiss={() => setInfoMessage(null)}
-                    action={{
-                        label: 'hide',
+                    visible={snackbarVisible}
+                    onDismiss={() => setSnackbarVisible(false)}
+                    action={info?.estimationState === EstimationState.Failed ? {
+                        label: 'delete',
                         onPress: () => {
-                            // Do something
-                        },
+                            console.log("infomessage", info)
+                            setDeleteVisible(true);
+                        }
+                    } : {
+                        label: 'hide',
+                        // do nothign will just hide it 
                     }}>
-                    {infoMessage}
+                    {info?.message}
                 </Snackbar>
+                {deleteVisible && (
+                    <ConfirmApiDialog
+                        apiCall={deleteAnimation}
+                        apiProps={[accessToken.accessToken, info?.estimationId]}
+                        visible={deleteVisible}
+                        hideDialog={() => (updateList(), setDeleteVisible(false))}
+                        startButtonText='Remove'
+                        text='Remove this failed animation?'
+                        apiDoneText='Animation is deleted!'
+                        apiLoadingText='Removing your animation...'
+                    />
+                )}
             </>
         </View>
     );

--- a/ReactNative/hooks/use-array-equals.ts
+++ b/ReactNative/hooks/use-array-equals.ts
@@ -1,0 +1,39 @@
+
+export const useArrayEquals = () => {
+
+    const arraysAreEqual = (arr1: string | any[], arr2: string | any[]) => {
+        if (arr1.length !== arr2.length) {
+            return false;
+        }
+
+        for (let i = 0; i < arr1.length; i++) {
+            if (!objectsAreEqual(arr1[i], arr2[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    const objectsAreEqual = (obj1: { [x: string]: any; }, obj2: { [x: string]: any; }) => {
+        const keys1 = Object.keys(obj1);
+        const keys2 = Object.keys(obj2);
+
+        if (keys1.length !== keys2.length) {
+            return false;
+        }
+
+        for (const key of keys1) {
+            if (obj1[key] !== obj2[key]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    return { arraysAreEqual }
+}
+
+
+


### PR DESCRIPTION
Added a delete dialogue to call the delete API.
Made it generic so the dialogue can be used for another API in the future, if need be.
Failed animations can be deleted from the animations page.
Successful animations can be deleted in the viewer page.
