### PR TITLE
Remove refresh on end reach

### DIFF
--- a/ReactNative/components/ui/list/endlessList.tsx
+++ b/ReactNative/components/ui/list/endlessList.tsx
@@ -58,8 +58,6 @@ export const EndlessList: React.FC<EndlessListProps> = ({
             data={estimations}
             renderItem={({ item }) => listItem(item, item.state === EstimationState.Success ? open : info)}
             keyExtractor={(_item, index) => index.toString()}
-            onEndReached={loadData}
-            onEndReachedThreshold={0.5}
             ListFooterComponent={() => displaySpinner ? <TextSpinner label='Getting your animations!' /> : null}
             ItemSeparatorComponent={divider}
         />


### PR DESCRIPTION
We want to keep the api calls to a minimum, giving a manual refresh option is not necessary -> this can change if we find the feedback to indicate something else.